### PR TITLE
Update to use node16.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: check-square
   color: purple
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
This mirrors https://github.com/ammaraskar/gcc-problem-matcher/commit/d1fed1fac9e94d30e23b5a82dba4e2963e71d2e7

Github has deprecated node12 actions so this needs to be updated to avoid producing a warning:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/