### PR TITLE
Update to use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: check-square
   color: purple
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
node16 have been deprecated by Github

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/