### PR TITLE
Update to use node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: check-square
   color: purple
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
Update to use node24
node20 have been deprecated by Github

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/